### PR TITLE
Bump up runtime version (from node4.3 to node6.10)

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -1,11 +1,13 @@
 service: ami
 
+frameworkVersion: ">=1.10.0 <2.0.0"
+
 plugins:
   - serverless-webpack
 
 provider:
   name: aws
-  runtime: nodejs4.3
+  runtime: nodejs6.10
   region: ${file(./constants.js):constants.AWS_REGION}
   iamRoleStatements:
     - Effect: Allow


### PR DESCRIPTION
Hi @boiyaa . Nice project ! Thank you !

I bumped up runtime version to Node6.10 ( and fixed frameworkVersion https://github.com/serverless/serverless/releases/tag/v1.10.0 )